### PR TITLE
Support user loading list of following (update status)

### DIFF
--- a/api/db/main.py
+++ b/api/db/main.py
@@ -81,7 +81,21 @@ def createUser():
 def updateUser():
     try:
         userId = request.args.get('id')
-        usersRef.document(userId).update(request.form)
+        usersRef.document(userId).update(request.get_json())
+        return json.dumps({'success': True})
+    except Exception as e:
+        return f"An Error Occured: {e}"
+
+@user_routes.route('/updateFollowing', methods=['POST'])
+def updatePlayback():
+    try:
+        userId = request.form.get('id')
+        followingRef = usersRef.where("followers", "array_contains", userId)
+        docs = followingRef.stream()
+        for doc in docs:
+            data = doc.to_dict()
+            payload = {'id': doc.id, 'access_token': data['spotify_access_token'], 'refresh_token': data['spotify_refresh_token']}
+            requests.get(f'{config.URL}{config.API_PREFIX}/spotify/me/playback', params=payload)
         return json.dumps({'success': True})
     except Exception as e:
         return f"An Error Occured: {e}"

--- a/api/spotify/main.py
+++ b/api/spotify/main.py
@@ -48,7 +48,7 @@ def getPlayback():
             currently_playing = requests.get(f'https://api.spotify.com/v1/me/player/currently-playing', headers=headers)
 
         if currently_playing.status_code == 204:
-            params = {'limit': 5}
+            params = {'limit': 1}
             recently_played = requests.get(f'https://api.spotify.com/v1/me/player/recently-played', headers=headers, params=params)
         else:
             recently_played = None

--- a/api/spotify/main.py
+++ b/api/spotify/main.py
@@ -55,7 +55,7 @@ def getPlayback():
 
         updatePayload = {
             'spotify_currently_playing': dict(currently_playing.json()) if currently_playing.status_code == 200 else None,
-            'spotify_recently_played': dict(recently_played.json()) if recently_played else None
+            'spotify_recently_played': dict(recently_played.json()['items'][0]) if recently_played else None
         }
         updateArgs = {'id': user_id}
 

--- a/api/spotify/main.py
+++ b/api/spotify/main.py
@@ -5,56 +5,78 @@ import json
 
 spotify_routes = Blueprint('spotify_routes', __name__)
 
-@spotify_routes.route('/me', methods=['GET'])
-def getMe():
-    userId = request.args.get('id')
-    if userId is not None:
+def parseUserTokens(request):
+    user_id = request.args.get('id')
+    access_token = request.args.get('access_token')
+    refresh_token = request.args.get('refresh_token')
+    assert user_id or (access_token and refresh_token), "Request must include either User ID or access and refresh tokens"
+    if not access_token or not refresh_token:
         userRes = requests.get(f'{config.URL}{config.API_PREFIX}/users/getUser', params={'id': userId})
         user = userRes.json()
         access_token = user['spotify_access_token']
         refresh_token = user['spotify_refresh_token']
-    else:
-        access_token = request.args.get('access_token')
-        refresh_token = request.args.get('refresh_token')
+    return user_id, access_token, refresh_token
 
-    headers = {'Authorization': f'Bearer {access_token}'}
-    res = requests.get('https://api.spotify.com/v1/me', headers=headers)
-    if res.status_code == 401:
-        access_token = refreshToken(refresh_token, userId)
-        params = {'access_token': access_token}
-        res = requests.get('https://api.spotify.com/v1/me', params=params)
-    return res.json()
+@spotify_routes.route('/me', methods=['GET'])
+def getMe():
+    try:
+        user_id, access_token, refresh_token = parseUserTokens(request)
+
+        headers = {'Authorization': f'Bearer {access_token}'}
+        res = requests.get('https://api.spotify.com/v1/me', headers=headers)
+        if res.status_code == 401:
+            access_token = refreshToken(refresh_token, user_id)
+            params = {'access_token': access_token}
+            res = requests.get('https://api.spotify.com/v1/me', params=params)
+        return res.json()
+    except Exception as e:
+        return f"An Error Occured: {e}"
 
 # TODO: add functionality to automatically refresh if necessary (maybe put in model?)
 
+# TODO: we should enable some batching on this endpoint - especially as it is used to get current status of following list
 @spotify_routes.route('/me/playback', methods=['GET'])
-def getPlaybackInfo():
-    userId = request.args.get('id')
-    if userId is not None:
-        userRes = requests.get(f'{config.URL}{config.API_PREFIX}/users/getUser', params={'id': userId})
-        user = userRes.json()
-        access_token = user['spotify_access_token']
-        refresh_token = user['spotify_refresh_token']
-    else:
-        access_token = request.args.get('access_token')
-        refresh_token = request.args.get('refresh_token')
+def getPlayback():
+    try:
+        user_id, access_token, refresh_token = parseUserTokens(request)
 
-    headers = {'Authorization': f'Bearer {access_token}'}
-    res = requests.get('https://api.spotify.com/v1/me/player', headers=headers)
-    if res.status_code == 401:
-        access_token = refreshToken(refresh_token, userId)
-        params = {'access_token': access_token}
-        res = requests.get('https://api.spotify.com/v1/me/player', params=params)
-    return res.json()
+        headers = {'Authorization': f'Bearer {access_token}'}
+        currently_playing = requests.get('https://api.spotify.com/v1/me/player/currently-playing', headers=headers)
+        if currently_playing.status_code == 401:
+            access_token = refreshToken(refresh_token, user_id)
+            headers = {'Authorization': f'Bearer {access_token}'}
+            currently_playing = requests.get(f'https://api.spotify.com/v1/me/player/currently-playing', headers=headers)
+
+        if currently_playing.status_code == 204:
+            params = {'limit': 5}
+            recently_played = requests.get(f'https://api.spotify.com/v1/me/player/recently-played', headers=headers, params=params)
+        else:
+            recently_played = None
+
+        updatePayload = {
+            'spotify_currently_playing': dict(currently_playing.json()) if currently_playing.status_code == 200 else None,
+            'spotify_recently_played': dict(recently_played.json()) if recently_played else None
+        }
+        updateArgs = {'id': user_id}
+
+        # updates user state in Firebase
+        requests.post(f'{config.URL}{config.API_PREFIX}/users/updateUser', params=updateArgs, json=updatePayload)
+        return json.dumps(updatePayload)
+    except Exception as e:
+        print(e)
+        return f"An Error Occured: {e}"
 
 def refreshToken(refreshToken, userId = None):
     try:
         tokensRes = requests.get(f'{config.URL}/auth/refreshToken', params={'refresh_token': refreshToken})
-        tokens = json.loads(tokensRes.text)
+        tokens = tokensRes.json()
         if userId is not None:
             updateArgs = {'id': userId}
             updatePayload = { 'spotify_access_token': tokens.get('access_token') }
+            if 'refresh_token' in tokens:
+                updatePayload['refresh_token'] = tokens['refresh_token']
             requests.put(f'{config.URL}{config.API_PREFIX}/users/updateUser', params=updateArgs, data=updatePayload)
         return tokens.get('access_token')
     except Exception as e:
+        print(e)
         return f"An Error Occured: {e}"


### PR DESCRIPTION
When a user loads the Guppy home/following page we need to show them the statues of all the other users they are following (what are they listening to - if anything). 

This PR is in conjunction with a frontend change that adds a request to `/api/users/updateFollowing` which should set off the following events:

- server checks for documents of users who the client user is following
- loops through those documents and requests `/spotify/me/playback`
- spotify playback endpoint finds token, refreshes it if necessary, gets current playback or if user not playing anything gets recent playback
- updates Firebase with current/recent playback